### PR TITLE
Patch with regex

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1,5 +1,7 @@
 package config
 
+import "regexp"
+
 const Version = "v1beta1"
 
 type Config struct {
@@ -117,8 +119,14 @@ type Patch struct {
 	// Path is the path of the patch
 	Path string `yaml:"path,omitempty" json:"path,omitempty"`
 
-	// Value is the value of the path
+	// Value is the new value to be set to the path
 	Value interface{} `yaml:"value,omitempty" json:"value,omitempty"`
+
+	// Regex - is regular expresion used to identify the Name,
+	// and optionally Namespace, parts of the field value that
+	// will be replaced with the rewritten Name and/or Namespace
+	Regex       string         `yaml:"regex,omitempty" json:"regex,omitempty"`
+	ParsedRegex *regexp.Regexp `yaml:"-" json:"-"`
 
 	// Conditions are conditions that must be true for
 	// the patch to get executed

--- a/pkg/patches/patch.go
+++ b/pkg/patches/patch.go
@@ -3,6 +3,8 @@ package patches
 import (
 	"encoding/json"
 	"fmt"
+	"regexp"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	jsonyaml "github.com/ghodss/yaml"
@@ -13,7 +15,7 @@ import (
 )
 
 type NameResolver interface {
-	TranslateName(name string, path string) (string, error)
+	TranslateName(name string, regex *regexp.Regexp, path string) (string, error)
 	TranslateLabelExpressionsSelector(selector *metav1.LabelSelector) (*metav1.LabelSelector, error)
 	TranslateLabelSelector(selector map[string]string) (map[string]string, error)
 }

--- a/pkg/patches/patch_test.go
+++ b/pkg/patches/patch_test.go
@@ -1,9 +1,11 @@
 package patches
 
 import (
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"regexp"
 	"strings"
 	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/loft-sh/vcluster-generic-crd-plugin/pkg/config"
 	yaml "gopkg.in/yaml.v3"
@@ -245,7 +247,7 @@ test2: {}`,
 
 type fakeNameResolver struct{}
 
-func (f *fakeNameResolver) TranslateName(name string, path string) (string, error) {
+func (f *fakeNameResolver) TranslateName(name string, _ *regexp.Regexp, path string) (string, error) {
 	return name, nil
 }
 

--- a/pkg/patches/patch_types.go
+++ b/pkg/patches/patch_types.go
@@ -12,11 +12,6 @@ import (
 	yaml "gopkg.in/yaml.v3"
 )
 
-const (
-	RegexNameGroup      = "NAME"
-	RegexNamespaceGroup = "NAMESPACE"
-)
-
 func CopyFromObject(obj1, obj2 *yaml.Node, patch *config.Patch) error {
 	if obj2 == nil {
 		return nil

--- a/pkg/patches/patch_types.go
+++ b/pkg/patches/patch_types.go
@@ -2,13 +2,19 @@ package patches
 
 import (
 	"fmt"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"strconv"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/loft-sh/vcluster-generic-crd-plugin/pkg/config"
 	yamlhelper "github.com/loft-sh/vcluster-generic-crd-plugin/pkg/util/yaml"
 	"github.com/pkg/errors"
 	yaml "gopkg.in/yaml.v3"
+)
+
+const (
+	RegexNameGroup      = "NAME"
+	RegexNamespaceGroup = "NAMESPACE"
 )
 
 func CopyFromObject(obj1, obj2 *yaml.Node, patch *config.Patch) error {
@@ -172,7 +178,7 @@ func RewriteName(obj1 *yaml.Node, patch *config.Patch, resolver NameResolver) er
 				continue
 			}
 
-			translatedName, err := resolver.TranslateName(m.Value, patch.FromPath)
+			translatedName, err := resolver.TranslateName(m.Value, patch.ParsedRegex, patch.FromPath)
 			if err != nil {
 				return err
 			}

--- a/pkg/patches/regex/regex.go
+++ b/pkg/patches/regex/regex.go
@@ -3,6 +3,7 @@ package regex
 import (
 	"regexp"
 	"sort"
+	"strings"
 
 	"k8s.io/apimachinery/pkg/types"
 )
@@ -11,6 +12,14 @@ const (
 	RegexNameGroup      = "NAME"
 	RegexNamespaceGroup = "NAMESPACE"
 )
+
+func PrepareRegex(regex string) (*regexp.Regexp, error) {
+	re := strings.TrimSpace(regex)
+	// replacement order is critical, replace $NAMESPACE first
+	re = strings.ReplaceAll(re, "$NAMESPACE", "(?P<NAMESPACE>[a-z0-9](?:[-a-z0-9]*[a-z0-9])?)")
+	re = strings.ReplaceAll(re, "$NAME", "(?P<NAME>[a-z](?:[-a-z0-9]*[a-z0-9])?)")
+	return regexp.Compile(re)
+}
 
 type RegexTranslateFunc func(name, namespace string) types.NamespacedName
 

--- a/pkg/patches/regex/regex.go
+++ b/pkg/patches/regex/regex.go
@@ -1,0 +1,90 @@
+package regex
+
+import (
+	"regexp"
+	"sort"
+
+	"k8s.io/apimachinery/pkg/types"
+)
+
+const (
+	RegexNameGroup      = "NAME"
+	RegexNamespaceGroup = "NAMESPACE"
+)
+
+type RegexTranslateFunc func(name, namespace string) types.NamespacedName
+
+func ProcessRegex(regex *regexp.Regexp, input string, translateFunc RegexTranslateFunc) string {
+	// Get group number of the named NAME and NAMESPACE regex groups
+	namePos := -1
+	namespacePos := -1
+	groupNames := regex.SubexpNames()
+	for pos, gn := range groupNames {
+		if gn == RegexNameGroup {
+			namePos = pos
+		} else if gn == RegexNamespaceGroup {
+			namespacePos = pos
+		}
+	}
+
+	// Find indexes of all matches and create a list of replacements from it
+	replacements := []IndexBasedRelaceItem{}
+	allIndexes := regex.FindAllStringSubmatchIndex(input, -1)
+	for _, indexes := range allIndexes {
+
+		if namePos != -1 && indexes[2*namePos] != -1 && indexes[2*namePos+1] != -1 {
+			name := input[indexes[2*namePos]:indexes[2*namePos+1]]
+			namespace := ""
+			if namespacePos != -1 && indexes[2*namespacePos] != -1 && indexes[2*namespacePos+1] != -1 {
+				// get the NAMESPACE value for use in the name translation
+				namespace = input[indexes[2*namespacePos]:indexes[2*namespacePos+1]]
+			}
+
+			translatedName := translateFunc(name, namespace)
+
+			replacements = append(replacements, IndexBasedRelaceItem{
+				StartIndex:  indexes[2*namePos],
+				EndIndex:    indexes[2*namePos+1],
+				Replacement: translatedName.Name,
+			})
+
+			if namespacePos != -1 && indexes[2*namespacePos] != -1 && indexes[2*namespacePos+1] != -1 {
+				replacements = append(replacements, IndexBasedRelaceItem{
+					StartIndex:  indexes[2*namespacePos],
+					EndIndex:    indexes[2*namespacePos+1],
+					Replacement: translatedName.Namespace,
+				})
+			}
+		}
+	}
+
+	return IndexBasedReplace(input, replacements)
+}
+
+type IndexBasedRelaceItem struct {
+	StartIndex  int
+	EndIndex    int
+	Replacement string
+}
+
+// IndexBasedReplace replaces multiple substrings in the input string
+// with the replacement values based on the indexes in the original input string.
+// input - string that will have parts of it replaced
+// items - slice of IndexBasedRelaceItem(s). Only nonoverlaping index pairs are supported.
+func IndexBasedReplace(input string, items []IndexBasedRelaceItem) string {
+	// sort thereplace items because otherwise indexOffset could cause
+	// panic due to out of bound access
+	sort.Slice(items, func(i, j int) bool {
+		return items[i].StartIndex < items[j].StartIndex
+	})
+
+	s := input
+	indexOffset := 0
+	for _, i := range items {
+		s = s[:i.StartIndex+indexOffset] + i.Replacement + s[i.EndIndex+indexOffset:]
+		// track how replacements affects indexes based on the difference between
+		// the length of the original substring and its replacement
+		indexOffset = indexOffset + len(i.Replacement) - (i.EndIndex - i.StartIndex)
+	}
+	return s
+}

--- a/pkg/syncer/back_syncer.go
+++ b/pkg/syncer/back_syncer.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"regexp"
 	"strings"
 
 	"github.com/loft-sh/vcluster-generic-crd-plugin/pkg/plugin"
@@ -543,7 +544,8 @@ type memorizingHostToVirtualNameResolver struct {
 	mappings map[string]string
 }
 
-func (r *memorizingHostToVirtualNameResolver) TranslateName(name string, path string) (string, error) {
+func (r *memorizingHostToVirtualNameResolver) TranslateName(name string, _ *regexp.Regexp, path string) (string, error) {
+	// TODO: add regex support
 	if r.mappings == nil {
 		r.mappings = map[string]string{}
 	}

--- a/pkg/syncer/from_virtual_syncer.go
+++ b/pkg/syncer/from_virtual_syncer.go
@@ -2,15 +2,18 @@ package syncer
 
 import (
 	"fmt"
+	"regexp"
+	"strings"
+
 	"github.com/loft-sh/vcluster-generic-crd-plugin/pkg/config"
 	"github.com/loft-sh/vcluster-generic-crd-plugin/pkg/namecache"
+	patchesregex "github.com/loft-sh/vcluster-generic-crd-plugin/pkg/patches/regex"
 	"github.com/loft-sh/vcluster-generic-crd-plugin/pkg/plugin"
 	"github.com/loft-sh/vcluster-sdk/log"
 	"github.com/loft-sh/vcluster-sdk/syncer"
 	synccontext "github.com/loft-sh/vcluster-sdk/syncer/context"
 	"github.com/loft-sh/vcluster-sdk/syncer/translator"
 	"github.com/loft-sh/vcluster-sdk/translate"
-	"github.com/pkg/errors"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -27,12 +30,16 @@ func CreateFromVirtualSyncer(ctx *synccontext.RegisterContext, config *config.Fr
 	obj.SetKind(config.Kind)
 	obj.SetAPIVersion(config.ApiVersion)
 
-	var err error
+	err := validateFromVirtualConfig(config)
+	if err != nil {
+		return nil, fmt.Errorf("invalid configuration for %s(%s) mapping: %v", config.Kind, config.ApiVersion, err)
+	}
+
 	var selector labels.Selector
-	if config.Selector != nil && len(config.Selector.LabelSelector) > 0 {
+	if config.Selector != nil {
 		selector, err = metav1.LabelSelectorAsSelector(metav1.SetAsLabelSelector(config.Selector.LabelSelector))
 		if err != nil {
-			return nil, errors.Wrap(err, "parse label selector")
+			return nil, fmt.Errorf("invalid selector in configuration for %s(%s) mapping: %v", config.Kind, config.ApiVersion, err)
 		}
 	}
 
@@ -47,10 +54,11 @@ func CreateFromVirtualSyncer(ctx *synccontext.RegisterContext, config *config.Fr
 			statusIsSubresource: statusIsSubresource,
 			log:                 log.New(config.Kind + "-from-virtual-syncer"),
 		},
-		gvk:       schema.FromAPIVersionAndKind(config.ApiVersion, config.Kind),
-		config:    config,
-		nameCache: nc,
-		selector:  selector,
+		gvk:             schema.FromAPIVersionAndKind(config.ApiVersion, config.Kind),
+		config:          config,
+		nameCache:       nc,
+		selector:        selector,
+		targetNamespace: ctx.TargetNamespace,
 	}, nil
 }
 
@@ -60,9 +68,10 @@ type fromVirtualController struct {
 	patcher *patcher
 	gvk     schema.GroupVersionKind
 
-	config    *config.FromVirtualCluster
-	nameCache namecache.NameCache
-	selector  labels.Selector
+	config          *config.FromVirtualCluster
+	nameCache       namecache.NameCache
+	selector        labels.Selector
+	targetNamespace string
 }
 
 func (f *fromVirtualController) SyncDown(ctx *synccontext.SyncContext, vObj client.Object) (ctrl.Result, error) {
@@ -75,7 +84,7 @@ func (f *fromVirtualController) SyncDown(ctx *synccontext.SyncContext, vObj clie
 	ctx.Log.Infof("Create physical %s %s/%s, since it is missing, but virtual object exists", f.config.Kind, vObj.GetNamespace(), vObj.GetName())
 	_, err := f.patcher.ApplyPatches(ctx.Context, vObj, nil, f.config.Patches, f.config.ReversePatches, func(vObj client.Object) (client.Object, error) {
 		return f.TranslateMetadata(vObj), nil
-	}, &virtualToHostNameResolver{namespace: vObj.GetNamespace()})
+	}, &virtualToHostNameResolver{namespace: vObj.GetNamespace(), targetNamespace: f.targetNamespace})
 	if err != nil {
 		f.EventRecorder().Eventf(vObj, "Warning", "SyncError", "Error syncing to physical cluster: %v", err)
 		return ctrl.Result{}, fmt.Errorf("error applying patches: %v", err)
@@ -123,7 +132,7 @@ func (f *fromVirtualController) Sync(ctx *synccontext.SyncContext, pObj client.O
 	// apply patches
 	_, err = f.patcher.ApplyPatches(ctx.Context, vObj, pObj, f.config.Patches, f.config.ReversePatches, func(vObj client.Object) (client.Object, error) {
 		return f.TranslateMetadata(vObj), nil
-	}, &virtualToHostNameResolver{namespace: vObj.GetNamespace()})
+	}, &virtualToHostNameResolver{namespace: vObj.GetNamespace(), targetNamespace: f.targetNamespace})
 	if err != nil {
 		if kerrors.IsInvalid(err) {
 			ctx.Log.Infof("Warning: this message could indicate a timing issue with no significant impact, or a bug. Please report this if your resource never reaches the expected state. Error message: failed to patch physical %s %s/%s: %v", f.config.Kind, vObj.GetNamespace(), vObj.GetName(), err)
@@ -186,12 +195,24 @@ func (f *fromVirtualController) objectMatches(obj client.Object) bool {
 }
 
 type virtualToHostNameResolver struct {
-	namespace string
+	namespace       string
+	targetNamespace string
 }
 
-func (r *virtualToHostNameResolver) TranslateName(name string, _ string) (string, error) {
-	return translate.PhysicalName(name, r.namespace), nil
+func (r *virtualToHostNameResolver) TranslateName(name string, regex *regexp.Regexp, _ string) (string, error) {
+	if regex != nil {
+		return patchesregex.ProcessRegex(regex, name, func(name, namespace string) types.NamespacedName {
+			// if the regex match doesn't contain namespace - use the namespace set in this resolver
+			if namespace == "" {
+				namespace = r.namespace
+			}
+			return types.NamespacedName{Namespace: r.targetNamespace, Name: translate.PhysicalName(name, namespace)}
+		}), nil
+	} else {
+		return translate.PhysicalName(name, r.namespace), nil
+	}
 }
+
 func (r *virtualToHostNameResolver) TranslateLabelExpressionsSelector(selector *metav1.LabelSelector) (*metav1.LabelSelector, error) {
 	if selector != nil {
 		if selector.MatchLabels == nil {
@@ -232,12 +253,22 @@ type hostToVirtualNameResolver struct {
 	nameCache namecache.NameCache
 }
 
-func (r *hostToVirtualNameResolver) TranslateName(name string, path string) (string, error) {
+func (r *hostToVirtualNameResolver) TranslateName(name string, regex *regexp.Regexp, path string) (string, error) {
 	var n types.NamespacedName
-	if path == "" {
-		n = r.nameCache.ResolveName(r.gvk, name)
+	if regex != nil {
+		return patchesregex.ProcessRegex(regex, name, func(name, namespace string) types.NamespacedName {
+			if path == "" {
+				return r.nameCache.ResolveName(r.gvk, name)
+			} else {
+				return r.nameCache.ResolveNamePath(r.gvk, name, path)
+			}
+		}), nil
 	} else {
-		n = r.nameCache.ResolveNamePath(r.gvk, name, path)
+		if path == "" {
+			n = r.nameCache.ResolveName(r.gvk, name)
+		} else {
+			n = r.nameCache.ResolveNamePath(r.gvk, name, path)
+		}
 	}
 	if n.Name == "" {
 		return "", fmt.Errorf("could not translate %s host resource name to vcluster resource name", name)
@@ -250,4 +281,17 @@ func (r *hostToVirtualNameResolver) TranslateLabelExpressionsSelector(selector *
 }
 func (r *hostToVirtualNameResolver) TranslateLabelSelector(selector map[string]string) (map[string]string, error) {
 	return nil, fmt.Errorf("translation not supported from host to virtual object")
+}
+
+func validateFromVirtualConfig(config *config.FromVirtualCluster) error {
+	for _, p := range append(config.Patches, config.ReversePatches...) {
+		if p.Regex != "" {
+			parsed, err := regexp.Compile(strings.TrimSpace(p.Regex))
+			if err != nil {
+				return fmt.Errorf("invalid Regex: %v", err)
+			}
+			p.ParsedRegex = parsed
+		}
+	}
+	return nil
 }

--- a/pkg/syncer/from_virtual_syncer.go
+++ b/pkg/syncer/from_virtual_syncer.go
@@ -3,7 +3,6 @@ package syncer
 import (
 	"fmt"
 	"regexp"
-	"strings"
 
 	"github.com/loft-sh/vcluster-generic-crd-plugin/pkg/config"
 	"github.com/loft-sh/vcluster-generic-crd-plugin/pkg/namecache"
@@ -286,11 +285,7 @@ func (r *hostToVirtualNameResolver) TranslateLabelSelector(selector map[string]s
 func validateFromVirtualConfig(config *config.FromVirtualCluster) error {
 	for _, p := range append(config.Patches, config.ReversePatches...) {
 		if p.Regex != "" {
-			re := strings.TrimSpace(p.Regex)
-			// replacement order is critical, replace $NAMESPACE first
-			re = strings.ReplaceAll(re, "$NAMESPACE", "?P<NAMESPACE>")
-			re = strings.ReplaceAll(re, "$NAME", "?P<NAME>")
-			parsed, err := regexp.Compile(re)
+			parsed, err := patchesregex.PrepareRegex(p.Regex)
 			if err != nil {
 				return fmt.Errorf("invalid Regex: %v", err)
 			}

--- a/pkg/syncer/from_virtual_syncer.go
+++ b/pkg/syncer/from_virtual_syncer.go
@@ -286,7 +286,11 @@ func (r *hostToVirtualNameResolver) TranslateLabelSelector(selector map[string]s
 func validateFromVirtualConfig(config *config.FromVirtualCluster) error {
 	for _, p := range append(config.Patches, config.ReversePatches...) {
 		if p.Regex != "" {
-			parsed, err := regexp.Compile(strings.TrimSpace(p.Regex))
+			re := strings.TrimSpace(p.Regex)
+			// replacement order is critical, replace $NAMESPACE first
+			re = strings.ReplaceAll(re, "$NAMESPACE", "?P<NAMESPACE>")
+			re = strings.ReplaceAll(re, "$NAME", "?P<NAME>")
+			parsed, err := regexp.Compile(re)
 			if err != nil {
 				return fmt.Errorf("invalid Regex: %v", err)
 			}


### PR DESCRIPTION
Adding support for regular expression to extract resource name and namespace from a string that should be translated.
Named capturing groups are used for this - `?P<NAME>` and `?P<NAMESPACE>`, or just `$NAME` and `$NAMESPACE`.
Example for the service urls:
```
patches:
- op: rewriteName
  path: spec.host
  regex: >
    ^$NAME((\.$NAMESPACE)?(\.svc(\.cluster\.local)?){1})?$
```