### PR TITLE
fix: error handling for configuration parsing & patch validation & selector translation

### DIFF
--- a/main.go
+++ b/main.go
@@ -35,14 +35,14 @@ func main() {
 	} else {
 		klog.Infof("Loading configuration:\n%s", c) //dev
 		configuration, err := config.ParseConfig(c)
+		if err != nil {
+			klog.Fatal(err)
+		}
 		loadedConfig, err := yaml.Marshal(configuration)
 		if err != nil {
 			klog.Fatal(err)
 		}
 		klog.Infof("Loaded configuration:\n%s", string(loadedConfig)) //dev
-		if err != nil {
-			klog.Fatal(err)
-		}
 
 		// TODO: efficiently sync all mapped CRDs from the host to vcluster or perhaps this should be a separate controller that will watch CRDs and sync changes
 		for _, m := range configuration.Mappings {

--- a/pkg/config/validate.go
+++ b/pkg/config/validate.go
@@ -101,7 +101,7 @@ func validatePatch(patch *Patch) error {
 		}
 
 		return nil
-	case PatchTypeRewriteName:
+	case PatchTypeRewriteName, PatchTypeRewriteLabelSelector, PatchTypeRewriteLabelExpressionsSelector:
 		return nil
 	case PatchTypeCopyFromObject:
 		if patch.FromPath == "" {

--- a/pkg/syncer/from_virtual_syncer.go
+++ b/pkg/syncer/from_virtual_syncer.go
@@ -213,37 +213,40 @@ func (r *virtualToHostNameResolver) TranslateName(name string, regex *regexp.Reg
 }
 
 func (r *virtualToHostNameResolver) TranslateLabelExpressionsSelector(selector *metav1.LabelSelector) (*metav1.LabelSelector, error) {
+	var s *metav1.LabelSelector
 	if selector != nil {
+		s = &metav1.LabelSelector{}
 		if selector.MatchLabels == nil {
-			selector.MatchLabels = map[string]string{}
+			s.MatchLabels = map[string]string{}
 		}
 		for k, v := range selector.MatchLabels {
-			selector.MatchLabels[translator.ConvertLabelKey(k)] = v
+			s.MatchLabels[translator.ConvertLabelKey(k)] = v
 		}
 		if len(selector.MatchExpressions) > 0 {
-			selector.MatchExpressions = []metav1.LabelSelectorRequirement{}
+			s.MatchExpressions = []metav1.LabelSelectorRequirement{}
 			for i, r := range selector.MatchExpressions {
-				selector.MatchExpressions[i] = metav1.LabelSelectorRequirement{
+				s.MatchExpressions[i] = metav1.LabelSelectorRequirement{
 					Key:      translator.ConvertLabelKey(r.Key),
 					Operator: r.Operator,
 					Values:   r.Values,
 				}
 			}
 		}
-		selector.MatchLabels[translate.NamespaceLabel] = r.namespace
-		selector.MatchLabels[translate.MarkerLabel] = translate.Suffix
+		s.MatchLabels[translate.NamespaceLabel] = r.namespace
+		s.MatchLabels[translate.MarkerLabel] = translate.Suffix
 	}
-	return selector, nil
+	return s, nil
 }
 func (r *virtualToHostNameResolver) TranslateLabelSelector(selector map[string]string) (map[string]string, error) {
+	s := map[string]string{}
 	if selector != nil {
 		for k, v := range selector {
-			selector[translator.ConvertLabelKey(k)] = v
+			s[translator.ConvertLabelKey(k)] = v
 		}
-		selector[translate.NamespaceLabel] = r.namespace
-		selector[translate.MarkerLabel] = translate.Suffix
+		s[translate.NamespaceLabel] = r.namespace
+		s[translate.MarkerLabel] = translate.Suffix
 	}
-	return selector, nil
+	return s, nil
 }
 
 type hostToVirtualNameResolver struct {


### PR DESCRIPTION
Small fix to avoid panic when an invalid configuration is passed.
Fix validation of the supported patch types.
Fix implementation of both label selector translation functions - they should produce a new selector object instead of writing into the passed one.