### PR TITLE
Add example plugin.yaml for contour and associated readme

### DIFF
--- a/crds/contour/README.md
+++ b/crds/contour/README.md
@@ -1,0 +1,37 @@
+# vcluster-contour-plugin
+
+This plugin syncs contour HTTPProxy resources created in the virtual cluster to the host cluster. It allows us to reuse a single contour ingress controller deployed on the host to manage and control the ingress traffic for all vclusters that run this plugin.
+
+## Quickstart
+
+Deploy vcluster with the plugin:
+```
+vcluster create my-vcluster -n my-vcluster -f crds/contour/plugin.yaml
+```
+
+Now wait until vcluster has started and deploy a HTTPProxy into the vcluster:
+
+`http-proxy.yaml`:
+```yaml
+apiVersion: projectcontour.io/v1
+kind: HTTPProxy
+metadata:
+  name: basic
+spec:
+  virtualhost:
+    fqdn: sampledomain.io
+    tls:
+      secretName: sname1234
+  routes:
+    - conditions:
+      - prefix: /prefix
+      services:
+        - name: httpnginx
+          port: 80
+      pathRewritePolicy:
+        replacePrefix:
+        - prefix: /prefix
+          replacement: /
+```
+
+The plugin ensures that tls.secretName and services.name are translated to their proper names on the host cluster.

--- a/crds/contour/plugin.yaml
+++ b/crds/contour/plugin.yaml
@@ -1,0 +1,35 @@
+# Plugin Definition below. This is essentially a valid helm values file that will be merged
+# with the other vcluster values during vcluster create or helm install.
+plugin:
+  contour:
+    image: ghcr.io/loft-sh/vcluster-plugins/generic-crd-plugin:bAosUsT
+    imagePullPolicy: IfNotPresent
+    rbac:
+      role:
+        extraRules:
+          - apiGroups: ["projectcontour.io"]
+            resources: ["httpproxies", "extensionservices"]
+            verbs: ["create", "delete", "patch", "update", "get", "list", "watch"]
+      clusterRole:
+        extraRules:
+          - apiGroups: ["apiextensions.k8s.io"]
+            resources: ["customresourcedefinitions"]
+            verbs: ["get", "list", "watch"]
+    env:
+      - name: CONFIG
+        value: |-
+          version: v1beta1
+          mappings:
+            - fromVirtualCluster:
+                # CRD for the apiVersion+Kind is implicitly copied to the virtual cluster
+                apiVersion: projectcontour.io/v1
+                kind: HTTPProxy
+                patches:
+                  - op: rewriteName
+                    path: spec.routes..services..name
+                  - op: rewriteName
+                    path: spec.virtualhost.tls.secretName
+                reversePatches:
+                  - op: copyFromObject
+                    fromPath: status
+                    path: status


### PR DESCRIPTION
This PR contains sample plugin.yaml to make Contour HTTPProxy work under vcluster. It also contains a README.md listing the steps required to create a vcluster using the plugin.