### PR TITLE
Rewrite namespace field in HTTPProxy Spec to the name of vcluster host namespace

### DIFF
--- a/crds/contour/plugin.yaml
+++ b/crds/contour/plugin.yaml
@@ -31,6 +31,12 @@ plugin:
                     path: spec.virtualhost.tls.secretName
                     sync:
                       secret: true
+                  - op: rewriteName
+                    path: spec.tcpproxy.services..name
+                  - op: rewriteName
+                    path: spec.includes
+                    namePath: name
+                    namespacePath: namespace
                 reversePatches:
                   - op: copyFromObject
                     fromPath: status

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -119,6 +119,12 @@ type Patch struct {
 	// Path is the path of the patch
 	Path string `yaml:"path,omitempty" json:"path,omitempty"`
 
+	// NamePath is the path to the name of a child resource within Path
+	NamePath string `yaml:"namePath,omitempty" json:"namePath,omitempty"`
+
+	// NamespacePath is path to the namespace of a child resource within Path
+	NamespacePath string `yaml:"namespacePath,omitempty" json:"namespacePath,omitempty"`
+
 	// Value is the new value to be set to the path
 	Value interface{} `yaml:"value,omitempty" json:"value,omitempty"`
 
@@ -144,7 +150,6 @@ type PatchType string
 
 const (
 	PatchTypeRewriteName                     = "rewriteName"
-	PatchTypeRewriteNamespaceRef             = "rewriteNamespaceRef"
 	PatchTypeRewriteLabelSelector            = "rewriteLabelSelector"
 	PatchTypeRewriteLabelExpressionsSelector = "rewriteLabelExpressionsSelector"
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -144,6 +144,7 @@ type PatchType string
 
 const (
 	PatchTypeRewriteName                     = "rewriteName"
+	PatchTypeRewriteNamespaceRef             = "rewriteNamespaceRef"
 	PatchTypeRewriteLabelSelector            = "rewriteLabelSelector"
 	PatchTypeRewriteLabelExpressionsSelector = "rewriteLabelExpressionsSelector"
 

--- a/pkg/config/validate.go
+++ b/pkg/config/validate.go
@@ -102,7 +102,7 @@ func validatePatch(patch *Patch) error {
 		}
 
 		return nil
-	case PatchTypeRewriteName, PatchTypeRewriteLabelSelector, PatchTypeRewriteLabelExpressionsSelector, PatchTypeRewriteNamespaceRef:
+	case PatchTypeRewriteName, PatchTypeRewriteLabelSelector, PatchTypeRewriteLabelExpressionsSelector:
 		return nil
 	case PatchTypeCopyFromObject:
 		if patch.FromPath == "" {

--- a/pkg/config/validate.go
+++ b/pkg/config/validate.go
@@ -102,7 +102,7 @@ func validatePatch(patch *Patch) error {
 		}
 
 		return nil
-	case PatchTypeRewriteName, PatchTypeRewriteLabelSelector, PatchTypeRewriteLabelExpressionsSelector:
+	case PatchTypeRewriteName, PatchTypeRewriteLabelSelector, PatchTypeRewriteLabelExpressionsSelector, PatchTypeRewriteNamespaceRef:
 		return nil
 	case PatchTypeCopyFromObject:
 		if patch.FromPath == "" {

--- a/pkg/patches/patch.go
+++ b/pkg/patches/patch.go
@@ -18,6 +18,7 @@ type NameResolver interface {
 	TranslateName(name string, regex *regexp.Regexp, path string) (string, error)
 	TranslateLabelExpressionsSelector(selector *metav1.LabelSelector) (*metav1.LabelSelector, error)
 	TranslateLabelSelector(selector map[string]string) (map[string]string, error)
+	TranslateNamespaceRef(namespace string) (string, error)
 }
 
 func ApplyPatches(obj1, obj2 client.Object, patchesConf []*config.Patch, reversePatchesConf []*config.Patch, nameResolver NameResolver) error {
@@ -73,6 +74,8 @@ func applyPatch(obj1, obj2 *yaml.Node, patch *config.Patch, resolver NameResolve
 	switch patch.Operation {
 	case config.PatchTypeRewriteName:
 		return RewriteName(obj1, patch, resolver)
+	case config.PatchTypeRewriteNamespaceRef:
+		return RewriteNamespaceRef(obj1, patch, resolver)
 	case config.PatchTypeRewriteLabelExpressionsSelector:
 		return RewriteLabelExpressionsSelector(obj1, patch, resolver)
 	case config.PatchTypeRewriteLabelSelector:

--- a/pkg/patches/patch.go
+++ b/pkg/patches/patch.go
@@ -18,6 +18,7 @@ type NameResolver interface {
 	TranslateName(name string, regex *regexp.Regexp, path string) (string, error)
 	TranslateLabelExpressionsSelector(selector *metav1.LabelSelector) (*metav1.LabelSelector, error)
 	TranslateLabelSelector(selector map[string]string) (map[string]string, error)
+	TranslateNameWithNamespace(name string, namespace string, regex *regexp.Regexp, path string) (string, error)
 	TranslateNamespaceRef(namespace string) (string, error)
 }
 
@@ -74,8 +75,6 @@ func applyPatch(obj1, obj2 *yaml.Node, patch *config.Patch, resolver NameResolve
 	switch patch.Operation {
 	case config.PatchTypeRewriteName:
 		return RewriteName(obj1, patch, resolver)
-	case config.PatchTypeRewriteNamespaceRef:
-		return RewriteNamespaceRef(obj1, patch, resolver)
 	case config.PatchTypeRewriteLabelExpressionsSelector:
 		return RewriteLabelExpressionsSelector(obj1, patch, resolver)
 	case config.PatchTypeRewriteLabelSelector:

--- a/pkg/patches/patch_test.go
+++ b/pkg/patches/patch_test.go
@@ -270,3 +270,7 @@ func (f *fakeNameResolver) TranslateLabelSelector(selector map[string]string) (m
 	selector["test"] = "test"
 	return selector, nil
 }
+
+func (f *fakeNameResolver) TranslateNamespaceRef(name string) (string, error) {
+	return "default", nil
+}

--- a/pkg/patches/patch_types.go
+++ b/pkg/patches/patch_types.go
@@ -191,6 +191,43 @@ func RewriteName(obj1 *yaml.Node, patch *config.Patch, resolver NameResolver) er
 	return nil
 }
 
+func RewriteNamespaceRef(obj1 *yaml.Node, patch *config.Patch, resolver NameResolver) error {
+	matches, err := FindMatches(obj1, patch.Path)
+	if err != nil {
+		return errors.Wrap(err, "find matches")
+	}
+
+	for _, m := range matches {
+		if m.Kind == yaml.ScalarNode {
+			// validated, err := ValidateAllConditions(obj1, m, patch.Conditions)
+			// if err != nil {
+			// 	return errors.Wrap(err, "validate conditions")
+			// } else if !validated {
+			// 	continue
+			// }
+
+			// translatedName, err := resolver.TranslateName(m.Value, patch.ParsedRegex, patch.FromPath)
+			// if err != nil {
+			// 	return err
+			// }
+
+			translatedNamespace, err := resolver.TranslateNamespaceRef(m.Value)
+			if err != nil {
+				return err
+			}
+
+			newNode, err := NewNode(translatedNamespace)
+			if err != nil {
+				return errors.Wrap(err, "create node")
+			}
+
+			ReplaceNode(obj1, m, newNode)
+		}
+	}
+
+	return nil
+}
+
 func RewriteLabelSelector(obj1 *yaml.Node, patch *config.Patch, resolver NameResolver) error {
 	matches, err := FindMatches(obj1, patch.Path)
 	if err != nil {

--- a/pkg/syncer/back_syncer.go
+++ b/pkg/syncer/back_syncer.go
@@ -567,6 +567,10 @@ func (r *memorizingHostToVirtualNameResolver) TranslateName(name string, _ *rege
 	r.mappings[key] = n.Name
 	return n.Name, nil
 }
+
+func (r *memorizingHostToVirtualNameResolver) TranslateNameWithNamespace(name string, namespace string, _ *regexp.Regexp, path string) (string, error) {
+	return "", fmt.Errorf("translation not supported from host to virtual object")
+}
 func (r *memorizingHostToVirtualNameResolver) TranslateLabelExpressionsSelector(selector *metav1.LabelSelector) (*metav1.LabelSelector, error) {
 	return nil, fmt.Errorf("translation not supported from host to virtual object")
 }

--- a/pkg/syncer/back_syncer.go
+++ b/pkg/syncer/back_syncer.go
@@ -573,3 +573,6 @@ func (r *memorizingHostToVirtualNameResolver) TranslateLabelExpressionsSelector(
 func (r *memorizingHostToVirtualNameResolver) TranslateLabelSelector(selector map[string]string) (map[string]string, error) {
 	return nil, fmt.Errorf("translation not supported from host to virtual object")
 }
+func (r *memorizingHostToVirtualNameResolver) TranslateNamespaceRef(namespace string) (string, error) {
+	return "", fmt.Errorf("translation not supported from host to virtual object")
+}

--- a/pkg/syncer/from_virtual_syncer.go
+++ b/pkg/syncer/from_virtual_syncer.go
@@ -199,16 +199,20 @@ type virtualToHostNameResolver struct {
 }
 
 func (r *virtualToHostNameResolver) TranslateName(name string, regex *regexp.Regexp, _ string) (string, error) {
+	return r.TranslateNameWithNamespace(name, r.namespace, regex, "")
+}
+
+func (r *virtualToHostNameResolver) TranslateNameWithNamespace(name string, namespace string, regex *regexp.Regexp, _ string) (string, error) {
 	if regex != nil {
-		return patchesregex.ProcessRegex(regex, name, func(name, namespace string) types.NamespacedName {
+		return patchesregex.ProcessRegex(regex, name, func(name, ns string) types.NamespacedName {
 			// if the regex match doesn't contain namespace - use the namespace set in this resolver
-			if namespace == "" {
-				namespace = r.namespace
+			if ns == "" {
+				ns = namespace
 			}
-			return types.NamespacedName{Namespace: r.targetNamespace, Name: translate.PhysicalName(name, namespace)}
+			return types.NamespacedName{Namespace: r.targetNamespace, Name: translate.PhysicalName(name, ns)}
 		}), nil
 	} else {
-		return translate.PhysicalName(name, r.namespace), nil
+		return translate.PhysicalName(name, namespace), nil
 	}
 }
 
@@ -247,10 +251,6 @@ func (r *virtualToHostNameResolver) TranslateLabelSelector(selector map[string]s
 }
 
 func (r *virtualToHostNameResolver) TranslateNamespaceRef(namespace string) (string, error) {
-	if r.targetNamespace == "" {
-		return "default", nil
-	}
-
 	return r.targetNamespace, nil
 }
 
@@ -282,6 +282,9 @@ func (r *hostToVirtualNameResolver) TranslateName(name string, regex *regexp.Reg
 	}
 
 	return n.Name, nil
+}
+func (r *hostToVirtualNameResolver) TranslateNameWithNamespace(name string, namespace string, regex *regexp.Regexp, path string) (string, error) {
+	return "", fmt.Errorf("translation not supported from host to virtual object")
 }
 func (r *hostToVirtualNameResolver) TranslateLabelExpressionsSelector(selector *metav1.LabelSelector) (*metav1.LabelSelector, error) {
 	return nil, fmt.Errorf("translation not supported from host to virtual object")

--- a/pkg/syncer/from_virtual_syncer.go
+++ b/pkg/syncer/from_virtual_syncer.go
@@ -246,6 +246,14 @@ func (r *virtualToHostNameResolver) TranslateLabelSelector(selector map[string]s
 	return s, nil
 }
 
+func (r *virtualToHostNameResolver) TranslateNamespaceRef(namespace string) (string, error) {
+	if r.targetNamespace == "" {
+		return "default", nil
+	}
+
+	return r.targetNamespace, nil
+}
+
 type hostToVirtualNameResolver struct {
 	gvk schema.GroupVersionKind
 
@@ -280,6 +288,9 @@ func (r *hostToVirtualNameResolver) TranslateLabelExpressionsSelector(selector *
 }
 func (r *hostToVirtualNameResolver) TranslateLabelSelector(selector map[string]string) (map[string]string, error) {
 	return nil, fmt.Errorf("translation not supported from host to virtual object")
+}
+func (r *hostToVirtualNameResolver) TranslateNamespaceRef(namespace string) (string, error) {
+	return "", fmt.Errorf("translation not supported from host to virtual object")
 }
 
 func validateFromVirtualConfig(config *config.FromVirtualCluster) error {


### PR DESCRIPTION
HTTPProxy permits the splitting of a system’s configuration into separate HTTPProxy instances using inclusion. Inclusion, as the name implies, allows for one HTTPProxy object to be included in another. Importantly, the included HTTPProxy objects do not have to be in the same namespace, they can be referenced in the root HTTPProxy by specifying their name and the namespace to which they belong.

```yaml
spec:
  virtualhost:
    fqdn: sachinlobo.io
  includes:
    - name: httpproxy-nginx
      namespace: nginx
    - name: httpproxy-apache
      namespace: apache
```


With this PR, when the root Proxy is synced to the host cluster, the namespace field is rewritten to the name of the vcluster host namespace, since all resources created inside the vcluster belong to this namespace on the host cluster. Additionally, the name field also needs gets rewritten appropriately taking a hint from the namespace field. This PR closes Feature Request #21 