### PR TITLE
Contour example plugin enable secret sync

### DIFF
--- a/crds/contour/plugin.yaml
+++ b/crds/contour/plugin.yaml
@@ -2,7 +2,7 @@
 # with the other vcluster values during vcluster create or helm install.
 plugin:
   contour:
-    image: ghcr.io/loft-sh/vcluster-plugins/generic-crd-plugin:bAosUsT
+    image: ghcr.io/loft-sh/vcluster-generic-crd-plugin
     imagePullPolicy: IfNotPresent
     rbac:
       role:

--- a/crds/contour/plugin.yaml
+++ b/crds/contour/plugin.yaml
@@ -29,6 +29,8 @@ plugin:
                     path: spec.routes..services..name
                   - op: rewriteName
                     path: spec.virtualhost.tls.secretName
+                    sync:
+                      secret: true
                 reversePatches:
                   - op: copyFromObject
                     fromPath: status


### PR DESCRIPTION
This PR enables syncing of secrets from vcluster to host cluster. It also updates the generic crd  plugin image repository.
Closes Issue #12 