### PR TITLE
feat: add ServiceMonitor (Prometheus) mapping

### DIFF
--- a/crds/prometheus-operator/Readme.md
+++ b/crds/prometheus-operator/Readme.md
@@ -1,0 +1,20 @@
+# How to use vcluster-generic-crd-sync-plugin to sync Prometheus Operator resources
+**Note**: Currently this plugin is still underdevelopment and is provided without any commercial support. You are encouraged to report problems via Issues in this repo. For the help with troubleshooting you can post to the "vcluster" channel in our Slack - https://slack.loft.sh/  
+**Note**: The configuration provided here is an example. Please review and update it to match your environment and use case.
+
+
+Prerequisite for installation are the Prometheus CRDs installed in the host cluster where vcluster will be installed.
+
+
+To install this plugin you need to pass the ./plugin.yaml file as additional source of Helm values during the installation. This is described in more detail in vcluster docs - https://www.vcluster.com/docs/plugins/overview#loading-and-installing-plugins-to-vcluster  
+For testing purposes you can refer to the plugin.yaml for the Prometheus Operator resources like so: `https://raw.githubusercontent.com/loft-sh/vcluster-generic-crd-sync-plugin/main/crds/prometheus-operator/plugin.yaml`.  
+Example installation command:
+```
+vcluster create -n vcluster vcluster -f https://raw.githubusercontent.com/loft-sh/vcluster-generic-crd-sync-plugin/main/crds/prometheus-operator/plugin.yaml
+```
+
+
+Once installed, the plugin will copy the CRDs from the host cluster into vcluster based on the configuration. Currently the configuration includes sync mappings only for the ServiceMonitor CRD. At this time the `.spec.namespaceSelector` of the ServiceMonitors created in the vcluster is ignored, all namespaces are selected.
+
+
+**Note:** Configuration provided in the ./plugin.yaml includes some parts that will likely need to be modified by the user. These parts are marked with yaml comments (E.g. `# User TODO:`) and provide further instructions. 

--- a/crds/prometheus-operator/plugin.yaml
+++ b/crds/prometheus-operator/plugin.yaml
@@ -1,0 +1,50 @@
+# Plugin Definition below. This is essentially a valid helm values file that will be merged
+# with the other vcluster values during vcluster create or helm install.
+plugin:
+  generic-crd-plugin:
+    image: ghcr.io/loft-sh/vcluster-generic-crd-plugin:0.0.1-alpha.3
+    imagePullPolicy: IfNotPresent
+    rbac:
+      role:
+        extraRules:
+          - apiGroups: ["monitoring.coreos.com"]
+            resources: ["servicemonitors"]
+            verbs: ["create", "delete", "patch", "update", "get", "list", "watch"]
+      clusterRole:
+        extraRules:
+          - apiGroups: ["apiextensions.k8s.io"]
+            resources: ["customresourcedefinitions"]
+            verbs: ["get", "list", "watch"]
+    env:
+      - name: CONFIG
+        value: |-
+          version: v1beta1
+          mappings:
+            - fromVirtualCluster:
+                apiVersion: monitoring.coreos.com/v1
+                kind: ServiceMonitor
+                patches:
+                  - op: add
+                    path: .metadata.labels
+                    #
+                    # User TODO:
+                    # Set the value below according to the .spec.serviceMonitorSelector of your Prometheus
+                    value:
+                      release: prometheus
+                  - op: rewriteName
+                    path: .spec.jobLabel
+                  - op: rewriteName
+                    path: .spec.targetLabels[*]
+                  - op: rewriteName
+                    path: .spec.podTargetLabels[*]
+                  - op: rewriteName
+                    path: .spec.endpoints[*]
+                  - op: rewriteLabelExpressionsSelector
+                    path: .spec.selector
+                    # TODO: Dev: add transformed namespace selectors to the label selectors (.spec.selector)
+                    # FR - https://github.com/loft-sh/vcluster-generic-crd-sync-plugin/issues/15
+                  - op: replace
+                    path: .spec.namespaceSelector
+                    value:
+                      any: false
+                      matchNames: []


### PR DESCRIPTION
Adding a basic mapping for the Prometheus ServiceMonitor based on the interest in Slack.
API docs: https://prometheus-operator.dev/docs/operator/api/#monitoring.coreos.com/v1.ServiceMonitor