### PR TITLE
Disallow multiple values for namespace references

### DIFF
--- a/pkg/patches/patch_test.go
+++ b/pkg/patches/patch_test.go
@@ -346,6 +346,28 @@ test2: {}`,
         nm: abc-x-pqr-x-` + fmt.Sprint(translate.Suffix) + `
         namespace: vcluster`,
 		},
+		{
+			name: "rewrite name - multiple name matches - multiple namespace references",
+			patch: &config.Patch{
+				Operation:     config.PatchTypeRewriteName,
+				Path:          "root.includes",
+				NamePath:      "..names..nm",
+				NamespacePath: "..namespaces..ns",
+			},
+			nameResolver: &fakeVirtualToHostNameResolver{
+				namespace:       "default",
+				targetNamespace: "vcluster",
+			},
+			obj1: `root:
+  includes:
+    - names:
+        - nm: abc
+        - nm: def
+      namespaces:
+        - ns: pqr
+        - ns: xyz`,
+			expectedErr: errors.New("found multiple namespace references"),
+		},
 	}
 
 	for _, testCase := range testCases {

--- a/pkg/patches/patch_types.go
+++ b/pkg/patches/patch_types.go
@@ -294,14 +294,11 @@ func GetNamespace(obj *yaml.Node, patch *config.Patch) (string, error) {
 		return namespace, errors.Wrap(err, "find matches namespace")
 	}
 
-	for _, m := range matches {
-		validated, err := ValidateAllConditions(obj, m, patch.Conditions)
-		if err != nil {
-			return namespace, errors.Wrap(err, "validate matchNamespace conditions")
-		} else if !validated {
-			continue
-		}
+	if len(matches) > 1 {
+		return namespace, errors.New("found multiple namespace references")
+	}
 
+	for _, m := range matches {
 		namespace = m.Value
 	}
 


### PR DESCRIPTION
Fixes Issue #23 

With this PR, the code will return with an error whenever multiple namespace references for a single resource are encountered. 