### PR TITLE
Rename yaml tag for SyncBase ID field to avoid confusion with name field of resource

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -25,7 +25,7 @@ type SyncBase struct {
 
 	// ID is the id of the controller. This is optional and only necessary if you have multiple syncBack or fromVirtualSyncer
 	// controllers that target the same group version kind.
-	ID string `yaml:"name,omitempty" json:"name,omitempty"`
+	ID string `yaml:"id,omitempty" json:"name,omitempty"`
 
 	// Patches are the patches to apply on the virtual cluster objects
 	// when syncing them from the host cluster


### PR DESCRIPTION
Based on observation while discussion with Oleg, proposing renaming the yaml field name of ID Field of SyncBase Go Type  from "name" to "id" to avoid confusion with the "name" field of the respective resource.

For example, to uniquely identify a back syncer mapping, we will be able to use 
```yaml
syncBack:
  - kind: Secret
    apiVersion: v1
    id: "secret-backsyncer-1"
    selectors:
      - name:
        rewrittenPath: spec.secretName
```
instead of 

```yaml
syncBack:
  - kind: Secret
    apiVersion: v1
    name: "secret-backsyncer-1"
    selectors:
      - name:
        rewrittenPath: spec.secretName
```