### PR TITLE
fix: set imagePullPolicy:Always in the examples

### DIFF
--- a/examples/cert-manager/plugin-without-ingress.yaml
+++ b/examples/cert-manager/plugin-without-ingress.yaml
@@ -2,8 +2,8 @@
 # with the other vcluster values during vcluster create or helm install.
 plugin:
   cert-manager:
-    image: ghcr.io/loft-sh/vcluster-generic-crd-plugin
-    imagePullPolicy: IfNotPresent
+    image: ghcr.io/loft-sh/vcluster-generic-crd-plugin:latest
+    imagePullPolicy: Always
     rbac:
       role:
         extraRules:

--- a/examples/contour/plugin.yaml
+++ b/examples/contour/plugin.yaml
@@ -2,8 +2,8 @@
 # with the other vcluster values during vcluster create or helm install.
 plugin:
   contour:
-    image: ghcr.io/loft-sh/vcluster-generic-crd-plugin
-    imagePullPolicy: IfNotPresent
+    image: ghcr.io/loft-sh/vcluster-generic-crd-plugin:latest
+    imagePullPolicy: Always
     rbac:
       role:
         extraRules:

--- a/examples/istio/plugin.yaml
+++ b/examples/istio/plugin.yaml
@@ -21,8 +21,8 @@ coredns:
 
 plugin:
   generic-crd-plugin:
-    image: ghcr.io/loft-sh/vcluster-generic-crd-plugin
-    imagePullPolicy: IfNotPresent
+    image: ghcr.io/loft-sh/vcluster-generic-crd-plugin:latest
+    imagePullPolicy: Always
     rbac:
       # extra namespaced permissions required for this plugin configuration
       role:

--- a/examples/prometheus-operator/plugin.yaml
+++ b/examples/prometheus-operator/plugin.yaml
@@ -2,8 +2,8 @@
 # with the other vcluster values during vcluster create or helm install.
 plugin:
   generic-crd-plugin:
-    image: ghcr.io/loft-sh/vcluster-generic-crd-plugin
-    imagePullPolicy: IfNotPresent
+    image: ghcr.io/loft-sh/vcluster-generic-crd-plugin:latest
+    imagePullPolicy: Always
     rbac:
       role:
         extraRules:


### PR DESCRIPTION
I am setting the image reference tag explicitly to `latest` for clarity + changing the pull policy to `Always` as that makes the most sense with the latest tag.