### PR TITLE
fix: improve handling of old host CRDs

### DIFF
--- a/vendor/github.com/loft-sh/vcluster-sdk/translate/crd.go
+++ b/vendor/github.com/loft-sh/vcluster-sdk/translate/crd.go
@@ -3,14 +3,15 @@ package translate
 import (
 	"context"
 	"fmt"
+	"math"
+	"time"
+
 	"github.com/pkg/errors"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apiextensionsv1clientset "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"math"
-	"time"
 
 	"github.com/loft-sh/vcluster-sdk/applier"
 	"github.com/loft-sh/vcluster-sdk/log"
@@ -53,6 +54,7 @@ func EnsureCRDFromPhysicalCluster(ctx context.Context, pConfig *rest.Config, vCo
 	crdDefinition.ManagedFields = nil
 	crdDefinition.OwnerReferences = nil
 	crdDefinition.Status = apiextensionsv1.CustomResourceDefinitionStatus{}
+	crdDefinition.Spec.PreserveUnknownFields = false
 	vClient, err := apiextensionsv1clientset.NewForConfig(vConfig)
 	if err != nil {
 		return err


### PR DESCRIPTION
Always set `.Spec.PreserveUnknownFields = false` because that is needed for compatibility with `apiextensions.k8s.io/v1`, as mentioned in the docs - https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/#field-pruning

**Release note:**
The `spec.preserveUnknownFields` field of CRDs copied from the host cluster will always be set to `false` 

This should fix problem reported by the user here - https://loft-sh.slack.com/archives/C01N273CF4P/p1669781095611459
Perhaps we should wait until user tries the patched version before merging?