### PR TITLE
fix: examples should not use imagePullPolicy: Always

### DIFF
--- a/examples/cert-manager/plugin-without-ingress.yaml
+++ b/examples/cert-manager/plugin-without-ingress.yaml
@@ -3,7 +3,7 @@
 plugin:
   cert-manager:
     image: ghcr.io/loft-sh/vcluster-generic-crd-plugin:latest
-    imagePullPolicy: Always
+    imagePullPolicy: IfNotPresent
     rbac:
       role:
         extraRules:

--- a/examples/contour/plugin.yaml
+++ b/examples/contour/plugin.yaml
@@ -3,7 +3,7 @@
 plugin:
   contour:
     image: ghcr.io/loft-sh/vcluster-generic-crd-plugin:latest
-    imagePullPolicy: Always
+    imagePullPolicy: IfNotPresent
     rbac:
       role:
         extraRules:

--- a/examples/istio/plugin.yaml
+++ b/examples/istio/plugin.yaml
@@ -22,7 +22,7 @@ coredns:
 plugin:
   generic-crd-plugin:
     image: ghcr.io/loft-sh/vcluster-generic-crd-plugin:latest
-    imagePullPolicy: Always
+    imagePullPolicy: IfNotPresent
     rbac:
       # extra namespaced permissions required for this plugin configuration
       role:

--- a/examples/prometheus-operator/plugin.yaml
+++ b/examples/prometheus-operator/plugin.yaml
@@ -3,7 +3,7 @@
 plugin:
   generic-crd-plugin:
     image: ghcr.io/loft-sh/vcluster-generic-crd-plugin:latest
-    imagePullPolicy: Always
+    imagePullPolicy: IfNotPresent
     rbac:
       role:
         extraRules:


### PR DESCRIPTION
The problem with this:
```
    image: ghcr.io/loft-sh/vcluster-generic-crd-plugin:latest
    imagePullPolicy: Always
```
is that when we release a breaking change users won't have a chance to react, and any pod recreating will cause issues for them.