### PR TITLE
Fix/sync down failed

### DIFF
--- a/main.go
+++ b/main.go
@@ -28,6 +28,9 @@ func main() {
 	if err != nil {
 		klog.Fatalf("Error initializing plugin: %v", err)
 	}
+	if registerCtx.TargetNamespace == "" {
+		registerCtx.TargetNamespace = registerCtx.CurrentNamespace
+	}
 
 	c := os.Getenv(ConfigurationEnvVar)
 	if c == "" {


### PR DESCRIPTION
- Set targetNamespace when it is nil, we need it to syncDown object to physical cluster
- We should use SyncDownCreate func to create physical object, instead of patch which would return error with no resource to patch.